### PR TITLE
feat: align GH actions to use exclude list instead of allowist

### DIFF
--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -28,7 +28,6 @@ jobs:
           pr-title: 'chore: Update GitHub Actions'
           commit-message: 'chore: update gitHub actions'
           file-glob: '.github/**/*.yml'
-          prefixes: 'actions'
           auto-merge: 'true'
 
       - name: Update GitHub Actions  (files in top-level non-hidden folders)
@@ -41,5 +40,4 @@ jobs:
           commit-message: 'feat: update `action.yml` files'
           file-glob: '[!.]*/action.yml'
           check-files: '[!.]*/action.yml'
-          prefixes: 'actions,hashicorp'
           auto-merge: 'true'

--- a/actions/README.md
+++ b/actions/README.md
@@ -1,7 +1,7 @@
 # Update GitHub Actions :arrows_counterclockwise:
 
-This GitHub Action scans `.github` workflows, finds `uses:` entries that match configured prefixes, compares them to the
-latest GitHub releases, and updates them when newer versions exist.
+This GitHub Action scans `.github` workflows, finds external `uses:` entries, compares them to the latest GitHub
+releases, and updates them when newer versions exist.
 
 ## :rocket: Usage
 
@@ -25,14 +25,18 @@ jobs:
           pr-title: 'Update GitHub Actions'
           commit-message: 'Update GitHub Actions'
           file-glob: '.github/**/*.yml'
-          prefixes: 'actions'
+          excluded-actions: 'docker,owner/legacy-action'
 ```
 
 ## :computer: Local CLI
 
 ```bash
-python cli.py --root /path/to/repo --file-glob '.github/**/*.yml' --prefixes 'actions'
+python cli.py --root /path/to/repo --file-glob '.github/**/*.yml' --excluded-actions 'docker,owner/legacy-action'
 ```
+
+By default, the action updates all external GitHub Actions with semver-like tags. Use `excluded-actions` to skip specific
+actions. Exclusions are comma-separated literal values, not regex or glob patterns. Each value can be an owner
+(`actions`), repository (`actions/checkout`), or action path (`owner/repo/path/to/action`).
 
 ## :gear: Inputs
 
@@ -44,9 +48,12 @@ python cli.py --root /path/to/repo --file-glob '.github/**/*.yml' --prefixes 'ac
 | `pr-title`          | Title for the pull request                                                                 | :x:                | `Update GitHub Actions` |
 | `commit-message`    | Commit message for the update                                                              | :x:                | `Update GitHub Actions` |
 | `file-glob`         | Glob for workflow files (relative to repo root)                                            | :x:                | `.github/**/*.yml`      |
-| `prefixes`          | Comma-separated list of action prefixes to include                                         | :x:                | `actions`               |
-| `auto-merge`        | Wether automatic merge should be enabled for the PR                                        | :x:                | `false`                 |
+| `check-files`       | Path/glob used to detect and include changed files in the PR                               | :x:                | `.github`               |
+| `excluded-actions`  | Comma-separated literal action owners, repositories, or paths to exclude                   | :x:                | -                       |
+| `app-slug`          | GitHub App slug for commit attribution                                                     | :x:                | -                       |
+| `auto-merge`        | Whether automatic merge should be enabled for the PR                                       | :x:                | `false`                 |
 | `skip-if-pr-exists` | Skip creating a new PR if an open PR with the same title already exists on the base branch | :x:                | `false`                 |
+| `dry-run`           | Run without creating a PR                                                                  | :x:                | `false`                 |
 
 ## :warning: Prerequisites
 

--- a/actions/action.yml
+++ b/actions/action.yml
@@ -38,10 +38,10 @@ inputs:
     description: 'Path/glob used to detect and include changed files in the PR'
     default: '.github'
 
-  prefixes:
+  excluded-actions:
     required: false
-    description: 'Comma-separated list of action prefixes to include'
-    default: 'actions'
+    description: 'Comma-separated list of action owners, repositories, or paths to exclude. Values are literal, not regex.'
+    default: ''
 
   app-slug:
     required: false
@@ -120,7 +120,7 @@ runs:
         python ${{ github.action_path }}/cli.py \
           --root "$GITHUB_WORKSPACE" \
           --file-glob "${{ inputs.file-glob }}" \
-          --prefixes "${{ inputs.prefixes }}"
+          --excluded-actions "${{ inputs.excluded-actions }}"
 
     - name: Check for changes
       id: check_changes

--- a/actions/cli.py
+++ b/actions/cli.py
@@ -21,9 +21,12 @@ def parse_args() -> argparse.Namespace:
         help="Glob (relative to root) for workflow files.",
     )
     parser.add_argument(
-        "--prefixes",
-        default="actions",
-        help="Comma-separated list of action prefixes to include.",
+        "--excluded-actions",
+        default="",
+        help=(
+            "Comma-separated list of action owners, repositories, or paths to "
+            "exclude. Values are matched literally, not as regex."
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -36,11 +39,11 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     root = Path(args.root).resolve()
-    prefixes = [p.strip() for p in args.prefixes.split(",") if p.strip()]
+    excluded_actions = [p.strip() for p in args.excluded_actions.split(",") if p.strip()]
     return update_actions(
         root=root,
         file_glob=args.file_glob,
-        prefixes=prefixes,
+        excluded_actions=excluded_actions,
         dry_run=args.dry_run,
     )
 

--- a/actions/cli.py
+++ b/actions/cli.py
@@ -39,7 +39,9 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     root = Path(args.root).resolve()
-    excluded_actions = [p.strip() for p in args.excluded_actions.split(",") if p.strip()]
+    excluded_actions = [
+        p.strip() for p in args.excluded_actions.split(",") if p.strip()
+    ]
     return update_actions(
         root=root,
         file_glob=args.file_glob,

--- a/actions/update_actions/tests/test_updater.py
+++ b/actions/update_actions/tests/test_updater.py
@@ -89,7 +89,7 @@ jobs:
                         updater.update_actions(
                             root=root,
                             file_glob=".github/**/*.yml",
-                            prefixes=["actions"],
+                            excluded_actions=[],
                             dry_run=False,
                         )
 
@@ -117,11 +117,103 @@ jobs:
                 updater.update_actions(
                     root=root,
                     file_glob=".github/**/*.yml",
-                    prefixes=["actions"],
+                    excluded_actions=[],
                     dry_run=True,
                 )
 
             self.assertEqual(workflow.read_text(encoding="utf-8"), original)
+
+    def test_update_actions_excludes_literal_owner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workflow_dir = root / ".github/workflows"
+            workflow_dir.mkdir(parents=True)
+            workflow = workflow_dir / "ci.yml"
+            original = """
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v3
+"""
+            workflow.write_text(original, encoding="utf-8")
+
+            with mock.patch(
+                "update_actions.updater.fetch_release_tags",
+                return_value=["v4"],
+            ):
+                updater.update_actions(
+                    root=root,
+                    file_glob=".github/**/*.yml",
+                    excluded_actions=["actions"],
+                    dry_run=False,
+                )
+
+            updated = workflow.read_text(encoding="utf-8")
+            self.assertIn("actions/checkout@v3", updated)
+            self.assertIn("hashicorp/setup-terraform@v4", updated)
+
+    def test_update_actions_exclusions_are_not_regex(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workflow_dir = root / ".github/workflows"
+            workflow_dir.mkdir(parents=True)
+            workflow = workflow_dir / "ci.yml"
+            workflow.write_text(
+                """
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v3
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch(
+                "update_actions.updater.fetch_release_tags",
+                return_value=["v4"],
+            ):
+                updater.update_actions(
+                    root=root,
+                    file_glob=".github/**/*.yml",
+                    excluded_actions=["actions/.*"],
+                    dry_run=False,
+                )
+
+            self.assertIn("actions/checkout@v4", workflow.read_text(encoding="utf-8"))
+
+    def test_update_actions_preserves_subdirectory_action_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workflow_dir = root / ".github/workflows"
+            workflow_dir.mkdir(parents=True)
+            workflow = workflow_dir / "ci.yml"
+            workflow.write_text(
+                """
+jobs:
+  build:
+    steps:
+      - uses: owner/repo/path/to/action@v1
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch(
+                "update_actions.updater.fetch_release_tags",
+                return_value=["v2"],
+            ) as fetch_release_tags:
+                updater.update_actions(
+                    root=root,
+                    file_glob=".github/**/*.yml",
+                    excluded_actions=[],
+                    dry_run=False,
+                )
+
+            fetch_release_tags.assert_called_once_with("owner/repo")
+            self.assertIn(
+                "owner/repo/path/to/action@v2",
+                workflow.read_text(encoding="utf-8"),
+            )
 
 
 if __name__ == "__main__":

--- a/actions/update_actions/updater.py
+++ b/actions/update_actions/updater.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
 
 from update_actions.github_api import fetch_release_tags
 from update_actions.scanner import (
@@ -15,7 +14,7 @@ from update_actions.versioning import parse_version, select_latest_tag
 def update_actions(
     root: Path,
     file_glob: str,
-    prefixes: list[str],
+    excluded_actions: list[str],
     dry_run: bool,
 ) -> int:
     workflow_files = collect_workflow_files(root, file_glob)
@@ -30,37 +29,49 @@ def update_actions(
         file_cache[path] = text
         uses_set.update(uses)
 
-    filtered_uses = []
+    excluded_actions_set = set(excluded_actions)
+    filtered_uses: list[tuple[str, str, str]] = []
     for use in sorted(uses_set):
         if "@" not in use:
             continue
-        if any(use.startswith(f"{prefix}/") for prefix in prefixes):
-            filtered_uses.append(use)
+        action_ref, current_tag = use.split("@", 1)
+        action_parts = action_ref.split("/")
+        if len(action_parts) < 2 or action_ref.startswith(("./", "../", "docker://")):
+            continue
+
+        release_repo = "/".join(action_parts[:2])
+        action_owner = action_parts[0]
+        if excluded_actions_set.intersection({action_owner, release_repo, action_ref}):
+            continue
+
+        filtered_uses.append((action_ref, release_repo, current_tag))
 
     if not filtered_uses:
         print("No matching action uses entries found.")
         return 0
 
     upgrades: dict[tuple[str, str], str] = {}
-    for use in filtered_uses:
-        repo, current_tag = use.split("@", 1)
+    release_tags_cache: dict[str, list[str]] = {}
+    for action_ref, release_repo, current_tag in filtered_uses:
         current_version = parse_version(current_tag)
         if current_version is None:
-            print(f"Skipping {use} (unsupported tag format)")
+            print(f"Skipping {action_ref}@{current_tag} (unsupported tag format)")
             continue
 
-        tags = fetch_release_tags(repo)
+        if release_repo not in release_tags_cache:
+            release_tags_cache[release_repo] = fetch_release_tags(release_repo)
+        tags = release_tags_cache[release_repo]
         latest_tag = select_latest_tag(tags)
         if latest_tag is None:
-            print(f"Skipping {use} (no valid release tags found)")
+            print(f"Skipping {action_ref}@{current_tag} (no valid release tags found)")
             continue
 
         latest_version = parse_version(latest_tag)
         if latest_version and latest_version > current_version:
-            upgrade_key = (repo, current_tag)
+            upgrade_key = (action_ref, current_tag)
             if upgrade_key not in upgrades:
                 upgrades[upgrade_key] = latest_tag
-                print(f"::notice::Updated {repo} from {current_tag} to {latest_tag}")
+                print(f"::notice::Updated {action_ref} from {current_tag} to {latest_tag}")
 
     if not upgrades:
         print("All matching actions are up to date.")

--- a/actions/update_actions/updater.py
+++ b/actions/update_actions/updater.py
@@ -71,7 +71,9 @@ def update_actions(
             upgrade_key = (action_ref, current_tag)
             if upgrade_key not in upgrades:
                 upgrades[upgrade_key] = latest_tag
-                print(f"::notice::Updated {action_ref} from {current_tag} to {latest_tag}")
+                print(
+                    f"::notice::Updated {action_ref} from {current_tag} to {latest_tag}"
+                )
 
     if not upgrades:
         print("All matching actions are up to date.")

--- a/cargo/README.md
+++ b/cargo/README.md
@@ -57,10 +57,12 @@ jobs:
 | `branch-prefix`     | Prefix for the update branch                                                               | :x:                | `update-dependencies`       |
 | `pr-title`          | Title for the pull request                                                                 | :x:                | `Update Cargo Dependencies` |
 | `commit-message`    | Commit message for the update                                                              | :x:                | `Update Cargo dependencies` |
+| `app-slug`          | GitHub App slug for commit attribution                                                     | :x:                | -                           |
 | `auto-merge`        | Whether automatic merge should be enabled for the PR                                       | :x:                | `false`                     |
 | `skip-if-pr-exists` | Skip creating a new PR if an open PR with the same title already exists on the base branch | :x:                | `false`                     |
 | `update-toolchain`  | Whether to update the Rust toolchain version                                               | :x:                | `true`                      |
 | `update-deps`       | Whether to update Cargo dependencies                                                       | :x:                | `true`                      |
+| `dry-run`           | Run without creating a PR                                                                  | :x:                | `false`                     |
 
 ## :mag: How It Works
 

--- a/circleci-orbs/README.md
+++ b/circleci-orbs/README.md
@@ -42,8 +42,10 @@ jobs:
 | `commit-message`       | Commit message for the update                                                              | :x:                | `Update CircleCI orbs` |
 | `circleci-config-file` | Path to CircleCI config file                                                               | :x:                | `.circleci/config.yml` |
 | `yq-version`           | Version of yq tool to use                                                                  | :x:                | `v4.44.1`              |
-| `auto-merge`           | Wether automatic merge should be enabled for the PR                                        | :x:                | `false`                |
+| `app-slug`             | GitHub App slug for commit attribution                                                     | :x:                | -                      |
+| `auto-merge`           | Whether automatic merge should be enabled for the PR                                       | :x:                | `false`                |
 | `skip-if-pr-exists`    | Skip creating a new PR if an open PR with the same title already exists on the base branch | :x:                | `false`                |
+| `dry-run`              | Run without creating a PR                                                                  | :x:                | `false`                |
 
 ## :warning: Prerequisites
 

--- a/golang/README.md
+++ b/golang/README.md
@@ -36,9 +36,11 @@ jobs:
 | `branch-prefix`     | Prefix for the update branch                                                               | :x:                | `update-dependencies`        |
 | `pr-title`          | Title for the pull request                                                                 | :x:                | `Update Golang Dependencies` |
 | `commit-message`    | Commit message for the update                                                              | :x:                | `Update Golang dependencies` |
-| `auto-merge`        | Wether automatic merge should be enabled for the PR                                        | :x:                | `false`                      |
+| `app-slug`          | GitHub App slug for commit attribution                                                     | :x:                | -                            |
+| `auto-merge`        | Whether automatic merge should be enabled for the PR                                       | :x:                | `false`                      |
 | `skip-if-pr-exists` | Skip creating a new PR if an open PR with the same title already exists on the base branch | :x:                | `false`                      |
 | `strategy`          | Dependency update strategy                                                                 | :x:                | `controlled`                 |
+| `dry-run`           | Run without creating a PR                                                                  | :x:                | `false`                      |
 
 ## 📋 Update Strategies
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -38,9 +38,11 @@ jobs:
 | `pr-title`          | Title for the pull request                                                                 | :x:                | `Update NPM Dependencies` |
 | `commit-message`    | Commit message for the update                                                              | :x:                | `Update NPM dependencies` |
 | `excluded-packages` | Comma-separated list of packages to exclude                                                | :x:                | -                         |
-| `relock`            | Wether `package-lock.json` should be regenerated                                           | :x:                | `false`                   |
-| `auto-merge`        | Wether automatic merge should be enabled for the PR                                        | :x:                | `false`                   |
+| `relock`            | Whether `package-lock.json` should be regenerated                                          | :x:                | `false`                   |
+| `app-slug`          | GitHub App slug for commit attribution                                                     | :x:                | -                         |
+| `auto-merge`        | Whether automatic merge should be enabled for the PR                                       | :x:                | `false`                   |
 | `skip-if-pr-exists` | Skip creating a new PR if an open PR with the same title already exists on the base branch | :x:                | `false`                   |
+| `dry-run`           | Run without creating a PR                                                                  | :x:                | `false`                   |
 
 ## :warning: Prerequisites
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -46,8 +46,10 @@ jobs:
 | `working-dir`       | Working directory for Terraform                                                            | :white_check_mark: | -                               |
 | `var-file-path`     | Path to Terraform variables file                                                           | :white_check_mark: | -                               |
 | `backend-config`    | Backend configuration value for `terraform init -backend-config=`                          | :x:                | -                               |
-| `auto-merge`        | Wether automatic merge should be enabled for the PR                                        | :x:                | `false`                         |
+| `app-slug`          | GitHub App slug for commit attribution                                                     | :x:                | -                               |
+| `auto-merge`        | Whether automatic merge should be enabled for the PR                                       | :x:                | `false`                         |
 | `skip-if-pr-exists` | Skip creating a new PR if an open PR with the same title already exists on the base branch | :x:                | `false`                         |
+| `dry-run`           | Run without creating a PR                                                                  | :x:                | `false`                         |
 
 ## :gear: How It Works
 


### PR DESCRIPTION
BREAKING CHANGE:

Github actions updater will now update everything by default, and only not update if defined as an exclude list, to align with conventions already present in the repo.